### PR TITLE
Special case for page number 2

### DIFF
--- a/src/app/code/community/Dh/SeoPagination/Model/Paginator.php
+++ b/src/app/code/community/Dh/SeoPagination/Model/Paginator.php
@@ -87,7 +87,12 @@ class Dh_SeoPagination_Model_Paginator extends Mage_Core_Model_Abstract
         
         //Determine exactly what needs to be output and 
         //add to the head block
-        if (!$pager->isFirstPage() && !$pager->isLastPage() && $numPages > 2 ) {
+        if ($pager->getCurrentPage() == 2) {
+            $moddedPreviousUrl =  str_replace('?p=1', '', $pager->getPreviousPageUrl());
+            $headBlock->addLinkRel('prev', $moddedPreviousUrl);
+            $headBlock->addLinkRel('next', $pager->getNextPageUrl());
+        }
+        elseif (!$pager->isFirstPage() && !$pager->isLastPage() && $numPages > 2 ) {
             $headBlock->addLinkRel('prev', $pager->getPreviousPageUrl());
             $headBlock->addLinkRel('next', $pager->getNextPageUrl());
         }


### PR DESCRIPTION
Hi,
in case of page number 2 it would be better to take the original url of category page instead of "?p=1". I´ve made it with a simple search/replace - could made with the ulr from controller.
Thanks
Oliver
