### PR TITLE
Add "Noindex,follow" function

### DIFF
--- a/src/app/code/community/Dh/SeoPagination/Model/Paginator.php
+++ b/src/app/code/community/Dh/SeoPagination/Model/Paginator.php
@@ -79,7 +79,7 @@ class Dh_SeoPagination_Model_Paginator extends Mage_Core_Model_Abstract
     private function getFirstPageUrl()
     {
         $pager = $this->getPager();
-        return $pager->getPagerUrl([$pager->getPageVarName() => null]);
+        return $pager->getPagerUrl(array($pager->getPageVarName() => null));
     }
 
     public function createLinks()

--- a/src/app/code/community/Dh/SeoPagination/Model/Paginator.php
+++ b/src/app/code/community/Dh/SeoPagination/Model/Paginator.php
@@ -2,6 +2,8 @@
 
 class Dh_SeoPagination_Model_Paginator extends Mage_Core_Model_Abstract
 {
+    const XML_PATH_NOINDEX_FOLLOW          = 'catalog/seo/seopagination_noindex';
+    
     /**
      * @var int
      */
@@ -97,6 +99,7 @@ class Dh_SeoPagination_Model_Paginator extends Mage_Core_Model_Abstract
 
         if ($pager->getCurrentPage() > 1) {
             $headBlock->addLinkRel('prev', $this->getPreviousPageUrl());
+            if(Mage::getStoreConfigFlag(self::XML_PATH_NOINDEX_FOLLOW)) $headBlock->setRobots('noindex,follow');
         }
     }
 }

--- a/src/app/code/community/Dh/SeoPagination/etc/system.xml
+++ b/src/app/code/community/Dh/SeoPagination/etc/system.xml
@@ -14,6 +14,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </seopagination_enabled>
+                        <seopagination_noindex translate="label" module="seopagination">
+                            <label>Allow only to index the first page. Set "noindex,follow" for the other pages.</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>11</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </seopagination_noindex>
                     </fields>
                 </seo>
             </groups>


### PR DESCRIPTION
It's a small gimmick for seo optimization to reduce double content.

If you have a category description on every page (?p=2...) you have double content. If you use a canonical-tag all products after page 1 will not be found, because they are no link to them.
But with this fix google can "see" all product links.

category.html?p=1 (index,follow)
category.html?p=2 (noindex,follow)
category.html?p=3 (noindex,follow)
....

http://www.michaelloy.de/magento-seo-paginierung-mit-relnext-relprev-und-noindexfollow/magento-seo-paginierung-mit-relnext-relprev-und-noindexfollow.html
